### PR TITLE
fix: allow false color red to be less than 3.5 stops above neutral grey

### DIFF
--- a/twk-fc.js
+++ b/twk-fc.js
@@ -324,11 +324,7 @@ TWKFC.prototype.testYellow = function() {
 	}
 };
 TWKFC.prototype.testRed = function() {
-	if (!isNaN(parseFloat(this.redInput.value)) && isFinite(this.redInput.value)) {
-		 if (parseFloat(this.redInput.value)<3.5) {
-			this.redInput.value = '3.5';
-		 }
-	} else {
+	if (isNaN(parseFloat(this.redInput.value)) || !isFinite(this.redInput.value)) {
 		this.redInput.value = '6';
 	}
 };


### PR DESCRIPTION
I had an issue with a steep Display Colourspace Conversion LUT (VLog/VGamut → HLG/Rec2020 → Rec709) where I couldn't set Red to ~2.3ev, and in some cases Orange is too similar to the color distortion that seems to happen before reaching the clipping point, so I wanted to fix this for others